### PR TITLE
Language server fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,10 @@
 FROM racket/racket
 
-RUN raco pkg install --auto racket-langserver
+RUN apt-get update \
+        && apt-get -y install --no-install-recommends curl xvfb git build-essential xauth \
+        && apt-get autoremove -y \
+        && apt-get clean -y
 
-RUN apt-get update && apt-get install -y xvfb
+RUN raco pkg install --auto racket-langserver
 
 RUN echo 'export FONTCONFIG_PATH=/etc/fonts' >>~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,13 +4,18 @@
 		"context": "..",
 		"dockerfile": "Dockerfile",
 	},
-
 	// Set custom container specific settings.json values on container create
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
+		"terminal.integrated.defaultProfile.linux": "bash",
 		"terminal.integrated.inheritEnv": false,
+		"magicRacket.languageServer.command": "xvfb-run",
+		"magicRacket.languageServer.arguments": [
+			"--auto-servernum",
+			"racket",
+			"--lib",
+			"racket-langserver"
+		],
 	},
-
 	// Add the IDs of extensions you want installed when the container is created
 	"extensions": [
 		"evzen-wybitul.magic-racket",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,5 +19,6 @@
 	// Add the IDs of extensions you want installed when the container is created
 	"extensions": [
 		"evzen-wybitul.magic-racket",
+		"andes.racket-repl"
 	],
 }


### PR DESCRIPTION
The problem with the language server has been finally fixed.

It looks like there were some missing dependencies that made the Racket language server to fail with error (i.e. `build-essential` and `xauth`).

I've also added another extension that I found very useful.